### PR TITLE
Install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+sudo apt-get install python-pip msgpack-python python-nfqueue python-imaging capstone -y
+sudo apt-get install python-requests python-configobj python-pefile -y
+pip install capstone
+./update.sh
+./install-bdfactory.sh
+./bdfactory/update.sh


### PR DESCRIPTION
Update in bdfactory still puts out missing capstone folder but this should be all the required packages for Kali.

Feel free to reject and add to README .
