### PR TITLE
Fix encoding in Inject plugin by using manual encoding detection, BS fails in some cases

### DIFF
--- a/plugins/inject.py
+++ b/plugins/inject.py
@@ -18,6 +18,8 @@
 
 import time
 import sys
+import re
+import chardet
 
 from bs4 import BeautifulSoup
 from plugins.plugin import Plugin
@@ -52,6 +54,7 @@ class Inject(Plugin):
         self.dtable        = {}
         self.count         = 0
 
+    
     def response(self, response, request, data):
 
         ip = response.getClientIP()
@@ -59,7 +62,22 @@ class Inject(Plugin):
         mime = response.headers['Content-Type']
 
         if self._should_inject(ip, hn) and self._ip_filter(ip) and self._host_filter(hn) and (hn not in self.ip) and ("text/html" in mime):
-            html = BeautifulSoup(data, "lxml")
+
+	    if "charset" in mime:
+		match = re.search('charset=(.*)', mime)
+		if match:
+			encoding = match.group(1).strip().replace('"', "")
+	    else:
+	    	try:
+			encoding = chardet.detect(data)["encoding"]
+		except:
+			encoding = None
+
+	    if encoding:		
+	            html = BeautifulSoup(data.decode(encoding, "ignore"), "lxml")
+	    else:
+	            html = BeautifulSoup(data, "lxml") # let bs find the encoding
+		
             if html.body:
 
                 if self.html_url:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ python-magic
 msgpack-python
 requests
 pypcap
+chardet


### PR DESCRIPTION
BeautifulSoup built-in encoding detection fails in some cases, more specific in my experiments encoding declaration in `encoding` function of `dammit.py` in BS select the wrong encoding.
So we are using `chardet` to recognize the encoding if header encoding is not specified.
And at the last attempt, let BS decide what encoding should be used.

Another choice can be html5lib since it has built-in encoding detection in its parser too.
http://html5lib.readthedocs.org/en/latest/movingparts.html#encoding-discovery

@byt3bl33d3r, please consider ```lxml``` in requirements.txt, it seems it did not install by default.