### PR TITLE
Fix improperly use config multiple nameservers

### DIFF
--- a/core/servers/DNS.py
+++ b/core/servers/DNS.py
@@ -449,7 +449,7 @@ class DNSChef(ConfigWatcher):
 
        # Use alternative DNS servers
         if config['nameservers']:
-            self.nameservers = config['nameservers'].split(',')
+            self.nameservers = config['nameservers']
 
         for section in config.sections:
 


### PR DESCRIPTION
ConfigObj currently splits multiple DNS into a list, so we don't need to split it again. trying this causes an exception and will eventually cause mitmf to exit. This commit fixes the issue.

```python
root@kali:~/MITMf#  python -u mitmf.py -i wlan1 --spoof --arp --gateway 192.168.1.1 --ignore 192.168.8.0/24 --capturefiles
[*] MITMf v0.9.8 - 'The Dark Side'
|_ CaptureFiles v0.1
|_ Spoof v0.6
AP_IDDDDD: 34
net.ipv4.ip_forward = 1
|  |_ ARP spoofing enabled
|
|_ Sergio-Proxy v0.2.1 online
|_ SSLstrip v0.9 by Moxie Marlinspike online
|
|_ Net-Creds v1.0 online
|_ MITMf-API online
 * Running on http://127.0.0.1:9999/ (Press CTRL+C to quit)
|_ HTTP server online
['8.8.8.8', '208.67.222.222']
Traceback (most recent call last):
  File "mitmf.py", line 157, in <module>
    DNSChef().start()
  File "/root/MITMf/core/servers/DNS.py", line 471, in start
    self.on_config_change()
  File "/root/MITMf/core/servers/DNS.py", line 452, in on_config_change
    self.nameservers = config['nameservers'].split(',')
AttributeError: 'list' object has no attribute 'split
```