### PR TITLE
Multiple fixes, netcreds, hsts dns, inject plugin

### DIFF
--- a/core/netcreds.py
+++ b/core/netcreds.py
@@ -916,7 +916,7 @@ def get_login_pass(body):
 
 def printer(src_ip_port, dst_ip_port, msg):
     if dst_ip_port != None:
-        print_str = '[{} > {}] {}'.format((src_ip_port, dst_ip_port, msg))
+        print_str = '[{} > {}] {}'.format(src_ip_port, dst_ip_port, msg)
         # All credentials will have dst_ip_port, URLs will not
 
         log.info("{}".format(print_str))

--- a/core/servers/DNS.py
+++ b/core/servers/DNS.py
@@ -366,7 +366,8 @@ class DNSHandler():
         #First proxy the request with the real domain
         q = DNSRecord.question(real_domain).pack()
         r = self.proxyrequest(q, *nameserver_tuple)
-        
+        if r is None: return None
+
         #Parse the answer
         dns_rr = DNSRecord.parse(r).rr
 

--- a/plugins/inject.py
+++ b/plugins/inject.py
@@ -64,7 +64,10 @@ class Inject(Plugin):
         try:
             mime = response.headers['Content-Type']
         except KeyError:
-            return
+            return {'response': response, 'request':request, 'data': data}
+
+        if "text/html" not in mime:
+            return {'response': response, 'request':request, 'data': data}
 
         if "charset" in mime:
             match = re.search('charset=(.*)', mime)


### PR DESCRIPTION
Hi, 

Here we have 4 bug fixes.
1. In `netcreds` module, An exception occurs  when printer tries to print info like ftp creds.  Changing format parameters fixed the issue.

2. there were 2 issues in inject plugin. first we need a dict as response returns. Second due to `chardet` heavy process (specially on binary contents) it is a good move to recognize content as soon as we can. So we will drop mimes other than `text/html` first.

3. `DNS` module in hsts bypass mode does not handle socket timeout properly. So if socket timeout occurred, we returns `None` to stop processing request and response and retry.

@byt3bl33d3r Please review all patches and let me know if there should be any changes.

Thank you