### PR TITLE
possible fix issue  #253 and #227

### DIFF
--- a/core/poisoners/ARP.py
+++ b/core/poisoners/ARP.py
@@ -215,7 +215,7 @@ class ARPpoisoner:
                             try:
                                 #log.debug("Poisoning {} <-> {}".format(targetip, self.gatewayip))
                                 self.s2.send(Ether(src=self.mymac, dst=targetmac)/ARP(pdst=targetip, psrc=self.gatewayip, hwdst=targetmac, op=arpmode))
-                                self.s2.send(Ether(src=targetmac, dst=self.gatewaymac)/ARP(pdst=self.gatewayip, psrc=targetip, hwdst=self.gatewaymac, op=arpmode))
+                                self.s2.send(Ether(src=self.mymac, dst=self.gatewaymac)/ARP(pdst=self.gatewayip, psrc=targetip, hwdst=self.gatewaymac, op=arpmode))
                             except Exception as e:
                                 if "Interrupted system call" not in e:
                                    log.error("Exception occurred while poisoning {}: {}".format(targetip, e))


### PR DESCRIPTION
small change to fix the "half duplex" issue. First; without the fix I don't receive any packets from the remote host to the target. I only received packets from the target to the remote host. Second; the original code wasn't "symmetric". Tested on kali2 with a linksys WRT54GL router on WiFI. Compared the ARP packets to those produced by ettercap, which was working correctly on my system. Including the fix resembles the ettercap method. It also works correctly when the arguments to the Ether() constructor are removed altogether.

Note that the problem occurs when not using any modules at all, only a simple filter and the spoofplugin. The problem may also be routerspecific, I dont know.
