### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-#Intentional contributors (in no particular order)
+# Intentional contributors (in no particular order)
 
 - @rthijssen
 - @ivangr0zni (Twitter)
@@ -13,7 +13,7 @@
 - @auraltension
 - @HAMIDx9
 
-#Unintentional contributors and/or projects that I stole code from
+# Unintentional contributors and/or projects that I stole code from
 
 - Metasploit Framework's os.js and Javascript Keylogger module
 - Responder by Laurent Gaffie

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/byt3bl33d3r/MITMf.svg)](https://travis-ci.org/byt3bl33d3r/MITMf)
 [![Coverage Status](https://coveralls.io/repos/byt3bl33d3r/MITMf/badge.svg?branch=master&service=github)](https://coveralls.io/github/byt3bl33d3r/MITMf?branch=master)
 
-#MITMf
+# MITMf
 
 Framework for Man-In-The-Middle attacks
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
