### PR TITLE
Fix typo

### DIFF
--- a/core/packetfilter.py
+++ b/core/packetfilter.py
@@ -28,7 +28,7 @@ class PacketFilter:
 
         for filter in self.filter:
             try:
-                execfile(i)
+                execfile(filter)
             except Exception:
                 log.debug("Error occurred in filter", filter)
                 print_exc()


### PR DESCRIPTION
Seems like the last contributor to `packetfilter.py` left a typo in the script.
It gave an error when using the `-F` option:
> NameError: global name 'i' is not defined

This PR should fix that.